### PR TITLE
[Suggestion] TreeNode now contains a Map<TreeNode,Integer> for it's subnodes.

### DIFF
--- a/src/main/java/info/aenterprise/recipeTree/tree/ItemStackNodeData.java
+++ b/src/main/java/info/aenterprise/recipeTree/tree/ItemStackNodeData.java
@@ -1,6 +1,7 @@
 package info.aenterprise.recipeTree.tree;
 
 import info.aenterprise.recipeTree.tree.generic.NodeData;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 /**
@@ -19,4 +20,19 @@ public class ItemStackNodeData extends NodeData<ItemStack>
 		return "Stack: " + data.toString() + ", X: " + getX() + ", Y: " + getY();
 	}
 
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ItemStackNodeData){
+			ItemStackNodeData other = (ItemStackNodeData) obj;
+			Item otherStack = other.getData().getItem();
+			Item thisStack = this.getData().getItem();
+			return otherStack == thisStack;
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return getData().getItem().hashCode();
+	}
 }

--- a/src/main/java/info/aenterprise/recipeTree/tree/ItemStackTreeNode.java
+++ b/src/main/java/info/aenterprise/recipeTree/tree/ItemStackTreeNode.java
@@ -54,4 +54,18 @@ public class ItemStackTreeNode extends TreeNode<ItemStack>
 		gui.mc.getRenderItem().renderItemOverlayIntoGUI(fontRenderer, data.getData(), data.getX() + 2, data.getY() + 2, null);
 		GlStateManager.popMatrix();
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof ItemStackTreeNode){
+			ItemStackTreeNode other = (ItemStackTreeNode) obj;
+			return other.data.equals(this.data);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.data.hashCode();
+	}
 }


### PR DESCRIPTION
This avoids having to create n equal objects, which in the end would end up in duplicate entries.

Eg: Lapis Lazuli Block, instead of 9 seperate TreeNode objects all containing the same subrecipes, now there's only 1 TreeNode, with an added counter.
This should reduce the memory requirement to calculate a giant recipe like the Infinite Tank / Mana Pool (FTB infinity) by a large factor.

@AEnterprise: I might have slightly broken the way you render the elements. Eg: Lapis Lazuli Block ==> 1 Lapis Block and 1 Lapis Dust are being rendered, because the Tree returns basically a list without duplicates (nature of the Map.keySet())
